### PR TITLE
Change target for SPM to SpotIMCore to match the artifact name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "SpotIMCore",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v11)
     ],
     products: [
         .library(name: "SpotIMCore", targets: ["WrapperSPMTarget"])
@@ -27,13 +27,13 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(
-            name: "SpotIMCoreXCFramework",
+            name: "SpotIMCore",
             path: "SpotImCore.xcframework"
         ),
         .target(
             name: "WrapperSPMTarget",
             dependencies: [
-                .target(name: "SpotIMCoreXCFramework", condition: .when(platforms: .some([.iOS]))),
+                .target(name: "SpotIMCore", condition: .when(platforms: .some([.iOS]))),
                 "Alamofire",
                 "PromiseKit",
                 "RxSwift",


### PR DESCRIPTION
See that issue:
https://stackoverflow.com/questions/71539013/spm-artifact-not-found-for-target-aaa-xcode-13-3-only

Change target name to SpotIMCore 
Also bump to v11 since Alamofire is using 10.2