### PR TITLE
Update iOS version to 11.0 (minimum for Xcode 14).

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2

--- a/SpotIMCore.podspec
+++ b/SpotIMCore.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.license         = { :type => 'CUSTOM', :file => 'LICENSE' }
   s.author          = { 'Alon Haiut' => 'alon.h@openweb.com' }
   s.platform        = :ios
-  s.ios.deployment_target = '10.3'
+  s.ios.deployment_target = '11.0'
   # Setting pod `BUILD_LIBRARY_FOR_DISTRIBUTION` to `YES`
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 


### PR DESCRIPTION
Update to macos-12 for Xcode 14 (macOS-latest is actually macos-11).

Xcode 14 support will be available from September 26
https://github.com/actions/runner-images/blob/releases/macOS-12/20220912/images/macos/macos-12-Readme.md